### PR TITLE
Align fetchFn with Pixi adapter signature

### DIFF
--- a/src/renderer/tiledAssetLoader.ts
+++ b/src/renderer/tiledAssetLoader.ts
@@ -24,9 +24,7 @@ import { TiledMap } from './TiledMap.js'
 
 extensions.add(GifAsset)
 
-export type FetchFn = (
-  url: string
-) => Promise<{ text(): Promise<string>; json(): Promise<unknown> }>
+export type FetchFn = ReturnType<typeof DOMAdapter.get>['fetch']
 export type LoadAssetFn = <T>(url: string) => Promise<T>
 
 export interface TiledAssetPipelineOptions {
@@ -56,7 +54,7 @@ interface LoadedTextureSets {
 export async function fetchMapDependencies(
   data: TiledMapData,
   basePath: string,
-  fetchFn: FetchFn = defaultFetch
+  fetchFn: FetchFn = DOMAdapter.get().fetch
 ): Promise<{
   externalTilesets: Map<string, TiledTileset>
   templates: Map<string, TiledObjectTemplate>
@@ -120,7 +118,7 @@ export async function loadTiledMapAsset(
   url: string,
   options?: TiledAssetPipelineOptions
 ): Promise<TiledMapAsset> {
-  const fetchFn = options?.fetchFn ?? defaultFetch
+  const fetchFn = options?.fetchFn ?? DOMAdapter.get().fetch
   const loadAsset = options?.loadAsset
   const data = await fetchTiledMapData(url, fetchFn)
   const basePath = pixiPath.dirname(url)
@@ -136,10 +134,6 @@ export async function loadTiledMapAsset(
   })
 
   return { mapData, container }
-}
-
-function defaultFetch(url: string): ReturnType<FetchFn> {
-  return DOMAdapter.get().fetch(url)
 }
 
 async function fetchTiledMapData(url: string, fetchFn: FetchFn): Promise<TiledMapData> {

--- a/test/renderer/tiledAssetLoader.test.ts
+++ b/test/renderer/tiledAssetLoader.test.ts
@@ -6,6 +6,7 @@ import { readFileSync } from 'node:fs'
 import { Assets, BufferImageSource, DOMAdapter, Mesh, Texture } from 'pixi.js'
 import { describe, expect, it, vi } from 'vitest'
 import {
+  type FetchFn,
   fetchMapDependencies,
   loadTextureManifest,
   loadTiledMapAsset
@@ -64,10 +65,11 @@ function makeMap(overrides: Partial<TiledMapData> = {}): TiledMapData {
 type FakeResponse = { text(): Promise<string>; json(): Promise<unknown> }
 
 function makeFetcher(responses: Record<string, FakeResponse>) {
-  return vi.fn((url: string): Promise<FakeResponse> => {
+  return vi.fn<FetchFn>((resource) => {
+    const url = String(resource)
     const entry = responses[url]
     if (!entry) return Promise.reject(new Error(`Unexpected fetch: ${url}`))
-    return Promise.resolve(entry)
+    return Promise.resolve(entry as Response)
   })
 }
 


### PR DESCRIPTION
## Summary
- Alias the exported FetchFn type to Pixi's DOMAdapter fetch signature.
- Use DOMAdapter.get().fetch directly as the default fetch function instead of a string-only wrapper.
- Update loader test doubles to satisfy the broader RequestInfo/RequestInit-compatible signature.

## Root cause
The previous defaultFetch wrapper preserved runtime behavior for current loader calls, but narrowed the public fetchFn contract to string-only and omitted the optional RequestInit argument from the fetch spec/Pixi adapter type.

## Validation
- npm run check
- npm run typecheck
- npm test