### PR TITLE
[bug] Fix repeated image layer parallax

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pixi-tiledmap",
-  "version": "2.8.2",
+  "version": "2.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pixi-tiledmap",
-      "version": "2.8.2",
+      "version": "2.8.3",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "^2.4.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pixi-tiledmap",
-  "version": "2.8.2",
+  "version": "2.8.3",
   "description": "Tiled Map Editor loader and renderer for PixiJS v8",
   "keywords": [
     "pixi",

--- a/src/renderer/ImageLayerRenderer.ts
+++ b/src/renderer/ImageLayerRenderer.ts
@@ -5,6 +5,7 @@ import { applyLayerState } from './renderableLayer.js'
 
 export class ImageLayerRenderer extends Container {
   readonly layerData: ResolvedImageLayer
+  private _tiledImage: TilingSprite | null = null
 
   constructor(
     layerData: ResolvedImageLayer,
@@ -40,12 +41,39 @@ export class ImageLayerRenderer extends Container {
     const spanH =
       ctx?.mapPixelHeight && ctx.mapPixelHeight > 0 ? ctx.mapPixelHeight : texture.height
 
-    this.addChild(
-      new TilingSprite({
-        texture,
-        width: repeatx ? spanW : texture.width,
-        height: repeaty ? spanH : texture.height
-      })
+    this._tiledImage = new TilingSprite({
+      texture,
+      width: repeatx ? spanW : texture.width,
+      height: repeaty ? spanH : texture.height
+    })
+    this.addChild(this._tiledImage)
+  }
+
+  applyParallax(
+    cameraX: number,
+    cameraY: number,
+    originX: number,
+    originY: number,
+    parentParallaxX: number,
+    parentParallaxY: number
+  ): void {
+    const dx = cameraX - originX
+    const dy = cameraY - originY
+    const effectiveParallaxX = this.layerData.parallaxx * parentParallaxX
+    const effectiveParallaxY = this.layerData.parallaxy * parentParallaxY
+    const repeatsX = this.layerData.repeatx && this._tiledImage !== null
+    const repeatsY = this.layerData.repeaty && this._tiledImage !== null
+
+    this.position.set(
+      this.layerData.offsetx + dx * (repeatsX ? parentParallaxX : 1 - effectiveParallaxX),
+      this.layerData.offsety + dy * (repeatsY ? parentParallaxY : 1 - effectiveParallaxY)
     )
+
+    if (this._tiledImage) {
+      this._tiledImage.tilePosition.set(
+        repeatsX ? -dx * effectiveParallaxX : 0,
+        repeatsY ? -dy * effectiveParallaxY : 0
+      )
+    }
   }
 }

--- a/src/renderer/layerTreeRenderer.ts
+++ b/src/renderer/layerTreeRenderer.ts
@@ -96,10 +96,14 @@ function applyParallaxRecursive(
   const px = layer.layerParallaxX * parentParallaxX
   const py = layer.layerParallaxY * parentParallaxY
 
-  layer.position.set(
-    layer.layerBaseOffsetX + (cameraX - originX) * (1 - px),
-    layer.layerBaseOffsetY + (cameraY - originY) * (1 - py)
-  )
+  if (layer instanceof ImageLayerRenderer) {
+    layer.applyParallax(cameraX, cameraY, originX, originY, parentParallaxX, parentParallaxY)
+  } else {
+    layer.position.set(
+      layer.layerBaseOffsetX + (cameraX - originX) * (1 - px),
+      layer.layerBaseOffsetY + (cameraY - originY) * (1 - py)
+    )
+  }
 
   for (const child of layer.children) {
     if (isRenderableLayer(child)) {

--- a/test/renderer/parallax.test.ts
+++ b/test/renderer/parallax.test.ts
@@ -1,6 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
+import { Texture, TilingSprite } from 'pixi.js'
 import { describe, expect, it } from 'vitest'
 import { TiledMap } from '../../src/renderer/TiledMap.js'
 import {
@@ -148,5 +149,37 @@ describe('TiledMap.applyParallax', () => {
     expect(outer.position.x).toBe(50)
     // inner effective parallax = 0.5 * 0.5 = 0.25 → 100 * (1 - 0.25) = 75
     expect(inner.position.x).toBe(75)
+  })
+
+  it('keeps repeated image layers covering the camera while scrolling the tiled texture', () => {
+    const map = new TiledMap(
+      makeResolvedMap({
+        width: 4,
+        height: 2,
+        tilewidth: 32,
+        tileheight: 32,
+        layers: [
+          makeResolvedImageLayer({
+            id: 1,
+            name: 'clouds',
+            image: 'clouds.png',
+            repeatx: true,
+            parallaxx: 0.5
+          })
+        ]
+      }),
+      {
+        imageLayerTextures: new Map([['clouds.png', Texture.EMPTY]])
+      }
+    )
+
+    const layer = map.getLayer('clouds')!
+    const tiledImage = layer.children[0]
+    expect(tiledImage).toBeInstanceOf(TilingSprite)
+
+    map.applyParallax(64, 0)
+
+    expect(layer.position.x).toBe(64)
+    expect((tiledImage as TilingSprite).tilePosition.x).toBe(-32)
   })
 })


### PR DESCRIPTION
## Summary
- Fix repeated image layers with parallax so the tiled area keeps covering the camera while the texture scrolls correctly.
- Add a regression test for a `repeatx` image layer using `applyParallax`.
- Bump package version to `2.8.3` for the patch release.

## Root cause
`TilingSprite` only repeats within its own finite rectangle. The previous implementation moved the image layer container for parallax, which could expose the edge of that rectangle after scrolling. Repeated axes now keep the repeat area camera-covered and apply parallax to `tilePosition` instead.

## Validation
- `npm run check`
- `npm run typecheck`
- `npm exec vitest run test/renderer/parallax.test.ts`
- `npm test`

Closes #26.