### PR TITLE
Fix repeated image layer parallax clipping

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pixi-tiledmap",
-  "version": "2.8.3",
+  "version": "2.8.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pixi-tiledmap",
-      "version": "2.8.3",
+      "version": "2.8.4",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "^2.4.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pixi-tiledmap",
-  "version": "2.8.3",
+  "version": "2.8.4",
   "description": "Tiled Map Editor loader and renderer for PixiJS v8",
   "keywords": [
     "pixi",

--- a/src/renderer/ImageLayerRenderer.ts
+++ b/src/renderer/ImageLayerRenderer.ts
@@ -63,13 +63,16 @@ export class ImageLayerRenderer extends Container {
     const effectiveParallaxY = this.layerData.parallaxy * parentParallaxY
     const repeatsX = this.layerData.repeatx && this._tiledImage !== null
     const repeatsY = this.layerData.repeaty && this._tiledImage !== null
+    const layerX = this.layerData.offsetx + dx * (1 - effectiveParallaxX)
+    const layerY = this.layerData.offsety + dy * (1 - effectiveParallaxY)
 
-    this.position.set(
-      this.layerData.offsetx + dx * (repeatsX ? parentParallaxX : 1 - effectiveParallaxX),
-      this.layerData.offsety + dy * (repeatsY ? parentParallaxY : 1 - effectiveParallaxY)
-    )
+    this.position.set(layerX, layerY)
 
     if (this._tiledImage) {
+      this._tiledImage.position.set(
+        repeatsX ? this.layerData.offsetx - layerX : 0,
+        repeatsY ? this.layerData.offsety - layerY : 0
+      )
       this._tiledImage.tilePosition.set(
         repeatsX ? -dx * effectiveParallaxX : 0,
         repeatsY ? -dy * effectiveParallaxY : 0

--- a/test/renderer/parallax.test.ts
+++ b/test/renderer/parallax.test.ts
@@ -151,7 +151,7 @@ describe('TiledMap.applyParallax', () => {
     expect(inner.position.x).toBe(75)
   })
 
-  it('keeps repeated image layers covering the camera while scrolling the tiled texture', () => {
+  it('keeps repeated image layers anchored while scrolling the tiled texture', () => {
     const map = new TiledMap(
       makeResolvedMap({
         width: 4,
@@ -164,7 +164,9 @@ describe('TiledMap.applyParallax', () => {
             name: 'clouds',
             image: 'clouds.png',
             repeatx: true,
-            parallaxx: 0.5
+            repeaty: true,
+            parallaxx: 0.5,
+            parallaxy: 0.5
           })
         ]
       }),
@@ -177,9 +179,48 @@ describe('TiledMap.applyParallax', () => {
     const tiledImage = layer.children[0]
     expect(tiledImage).toBeInstanceOf(TilingSprite)
 
-    map.applyParallax(64, 0)
+    map.applyParallax(100, 100)
 
-    expect(layer.position.x).toBe(64)
-    expect((tiledImage as TilingSprite).tilePosition.x).toBe(-32)
+    expect(layer.position.x + tiledImage.position.x).toBe(0)
+    expect(layer.position.y + tiledImage.position.y).toBe(0)
+    expect((tiledImage as TilingSprite).tilePosition.x).toBe(-50)
+    expect((tiledImage as TilingSprite).tilePosition.y).toBe(-50)
+  })
+
+  it('only anchors the axes that repeat', () => {
+    const map = new TiledMap(
+      makeResolvedMap({
+        width: 4,
+        height: 2,
+        tilewidth: 32,
+        tileheight: 32,
+        layers: [
+          makeResolvedImageLayer({
+            id: 1,
+            name: 'mist',
+            image: 'mist.png',
+            repeatx: true,
+            repeaty: false,
+            parallaxx: 0.5,
+            parallaxy: 0.25
+          })
+        ]
+      }),
+      {
+        imageLayerTextures: new Map([['mist.png', Texture.EMPTY]])
+      }
+    )
+
+    const layer = map.getLayer('mist')!
+    const tiledImage = layer.children[0]
+    expect(tiledImage).toBeInstanceOf(TilingSprite)
+
+    map.applyParallax(100, 100)
+
+    expect(layer.position.x + tiledImage.position.x).toBe(0)
+    expect(layer.position.y).toBe(75)
+    expect(tiledImage.position.y).toBe(0)
+    expect((tiledImage as TilingSprite).tilePosition.x).toBe(-50)
+    expect((tiledImage as TilingSprite).tilePosition.y).toBe(0)
   })
 })


### PR DESCRIPTION
## Summary
- Keep repeated image layer tiling areas anchored instead of moving the finite TilingSprite rectangle to the camera position.
- Continue scrolling repeated textures through tilePosition using the effective parallax factor.
- Add regression coverage for repeat-both and repeat-x-only image layers after applyParallax(100, 100).
- Bump package version to 2.8.4.

## Root cause
The 2.8.3 fix moved the TilingSprite container to the camera coordinate for repeated axes. That kept one camera model covered, but made the visible tiling rectangle begin at applyParallax(cameraX, cameraY), leaving the top and left clipped exactly as reported.

## Validation
- npm run check
- npm run typecheck
- npm exec vitest run test/renderer/parallax.test.ts
- npm test

Closes #26.