### PR TITLE
Fix XML parsers for web workers and Node (#29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,16 @@ map.setTile('details', 10, 6, { tileset: 'dungeon', tileId: 42 });
 | `parseTx(xml)`        | Parse TX XML string → `TiledObjectTemplate` data                 |
 | `decodeGid(raw)`      | Decode a raw GID into tile ID + flip flags                       |
 
+#### XML parsing outside the browser
+
+`parseTmx`, `parseTsx`, and `parseTx` parse XML through PixiJS' `DOMAdapter`, so they work in browsers, web workers, and Node. In the browser the default adapter is used automatically. In a web worker or in Node there is no global `DOMParser`, so configure a DOM-capable adapter once at startup before parsing:
+
+```ts
+import { DOMAdapter, WebWorkerAdapter } from 'pixi.js'
+
+DOMAdapter.set(WebWorkerAdapter) // uses @xmldom/xmldom under the hood
+```
+
 ### Low-Level Packing
 
 `PackedTileLayerRenderer.addTextureRect()` is available for renderer-level integrations that need to pack an already-resolved texture rectangle without going through Tiled tile placement. It uses the same batch sizing, texture-source/alpha grouping, cached quad indices, and final `MeshGeometry` path as normal tile layers.

--- a/src/parser/parseTmx.ts
+++ b/src/parser/parseTmx.ts
@@ -1,3 +1,4 @@
+import { DOMAdapter } from 'pixi.js'
 import type {
   TiledDrawOrder,
   TiledLayer,
@@ -15,7 +16,18 @@ import { parseData } from './tmxData.js'
 import { parseObject } from './tmxObjects.js'
 import { parseProperties } from './tmxProperties.js'
 import { parseImage, parseTileset } from './tmxTilesets.js'
-import { bool, child, children, float, int, optFloat, optInt, optStr, str } from './xmlHelpers.js'
+import {
+  bool,
+  child,
+  children,
+  elementChildren,
+  float,
+  int,
+  optFloat,
+  optInt,
+  optStr,
+  str
+} from './xmlHelpers.js'
 
 // ─── Layers ─────────────────────────────────────────────────────────────────
 
@@ -86,8 +98,9 @@ function parseGroupLayer(el: Element): TiledLayer {
 
 function parseLayers(parentEl: Element): TiledLayer[] {
   const layers: TiledLayer[] = []
-  for (let i = 0; i < parentEl.children.length; i++) {
-    const el = parentEl.children[i]!
+  const childEls = elementChildren(parentEl)
+  for (let i = 0; i < childEls.length; i++) {
+    const el = childEls[i]!
     switch (el.tagName) {
       case 'layer':
         layers.push(parseTileLayer(el))
@@ -108,14 +121,23 @@ function parseLayers(parentEl: Element): TiledLayer[] {
 
 // ─── Map ────────────────────────────────────────────────────────────────────
 
-export function parseTmx(xml: string): TiledMap {
-  const parser = new DOMParser()
-  const doc = parser.parseFromString(xml, 'text/xml')
+// Parse an XML string into a Document via Pixi's DOMAdapter so the parser works
+// in browsers, web workers, and Node (see https://github.com/riebel/pixi-tiledmap/issues/29).
+function parseXmlDocument(xml: string, kind: string): Document {
+  const doc = DOMAdapter.get().parseXML(xml)
 
-  const errorNode = doc.querySelector('parsererror')
+  // Browsers surface malformed XML as a <parsererror> element. Use
+  // getElementsByTagName rather than querySelector, which xmldom does not implement.
+  const errorNode = doc.getElementsByTagName('parsererror')[0]
   if (errorNode) {
-    throw new Error(`TMX XML parse error: ${errorNode.textContent}`)
+    throw new Error(`${kind} XML parse error: ${errorNode.textContent}`)
   }
+
+  return doc
+}
+
+export function parseTmx(xml: string): TiledMap {
+  const doc = parseXmlDocument(xml, 'TMX')
 
   const mapEl = doc.documentElement
   if (mapEl.tagName !== 'map') {
@@ -156,13 +178,7 @@ export function parseTmx(xml: string): TiledMap {
 }
 
 export function parseTsx(xml: string): TiledTileset {
-  const parser = new DOMParser()
-  const doc = parser.parseFromString(xml, 'text/xml')
-
-  const errorNode = doc.querySelector('parsererror')
-  if (errorNode) {
-    throw new Error(`TSX XML parse error: ${errorNode.textContent}`)
-  }
+  const doc = parseXmlDocument(xml, 'TSX')
 
   const tsEl = doc.documentElement
   if (tsEl.tagName !== 'tileset') {
@@ -179,13 +195,7 @@ export function parseTsx(xml: string): TiledTileset {
 // ─── Template (TX) ──────────────────────────────────────────────────────────
 
 export function parseTx(xml: string): TiledObjectTemplate {
-  const parser = new DOMParser()
-  const doc = parser.parseFromString(xml, 'text/xml')
-
-  const errorNode = doc.querySelector('parsererror')
-  if (errorNode) {
-    throw new Error(`TX XML parse error: ${errorNode.textContent}`)
-  }
+  const doc = parseXmlDocument(xml, 'TX')
 
   const tplEl = doc.documentElement
   if (tplEl.tagName !== 'template') {

--- a/src/parser/xmlHelpers.ts
+++ b/src/parser/xmlHelpers.ts
@@ -33,19 +33,40 @@ export function optFloat(el: Element, name: string): number | undefined {
   return value != null ? parseFloat(value) : undefined
 }
 
+// `Element.children` is not implemented by every DOM backend Pixi's DOMAdapter
+// may use (notably `@xmldom/xmldom` in web workers / Node). Iterate `childNodes`
+// and filter to element nodes instead, which is universally supported.
+const ELEMENT_NODE = 1
+
+function isElementNode(node: ChildNode): node is Element {
+  return node.nodeType === ELEMENT_NODE
+}
+
+export function elementChildren(el: Element): Element[] {
+  const result: Element[] = []
+  const nodes = el.childNodes
+  for (let i = 0; i < nodes.length; i++) {
+    const node = nodes[i]!
+    if (isElementNode(node)) result.push(node)
+  }
+  return result
+}
+
 export function children(el: Element, tag: string): Element[] {
   const result: Element[] = []
-  for (let i = 0; i < el.children.length; i++) {
-    const child = el.children[i]!
-    if (child.tagName === tag) result.push(child)
+  const nodes = el.childNodes
+  for (let i = 0; i < nodes.length; i++) {
+    const node = nodes[i]!
+    if (isElementNode(node) && node.tagName === tag) result.push(node)
   }
   return result
 }
 
 export function child(el: Element, tag: string): Element | null {
-  for (let i = 0; i < el.children.length; i++) {
-    const current = el.children[i]!
-    if (current.tagName === tag) return current
+  const nodes = el.childNodes
+  for (let i = 0; i < nodes.length; i++) {
+    const node = nodes[i]!
+    if (isElementNode(node) && node.tagName === tag) return node
   }
   return null
 }

--- a/test/parser/parseTmx.test.ts
+++ b/test/parser/parseTmx.test.ts
@@ -1,7 +1,8 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, expect, it } from 'vitest'
+import { DOMAdapter, WebWorkerAdapter } from 'pixi.js'
+import { afterEach, describe, expect, it } from 'vitest'
 import { parseTmx, parseTsx, parseTx } from '../../src/parser/parseTmx.js'
 
 describe('parseTmx', () => {
@@ -447,5 +448,72 @@ describe('parseTx', () => {
 
   it('throws when template has no <object>', () => {
     expect(() => parseTx('<template/>')).toThrow('missing <object>')
+  })
+})
+
+// Regression for https://github.com/riebel/pixi-tiledmap/issues/29: the XML
+// parsers must not depend on browser-only DOM APIs (DOMParser, querySelector,
+// Element.children). Driving them through Pixi's WebWorkerAdapter, which is
+// backed by @xmldom/xmldom, exercises the worker/Node code path.
+describe('XML parsing under WebWorkerAdapter (xmldom)', () => {
+  const original = DOMAdapter.get()
+
+  afterEach(() => {
+    // Restore the jsdom-backed default for the remaining suites in this file.
+    DOMAdapter.set(original)
+  })
+
+  it('parses a TMX map with nested layers', () => {
+    DOMAdapter.set(WebWorkerAdapter)
+
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.10" orientation="orthogonal" renderorder="right-down"
+     width="2" height="1" tilewidth="32" tileheight="32" infinite="0"
+     nextlayerid="3" nextobjectid="1">
+  <tileset firstgid="1" name="test" tilewidth="32" tileheight="32"
+           tilecount="2" columns="2">
+    <image source="test.png" width="64" height="32"/>
+  </tileset>
+  <group id="2" name="grp">
+    <layer id="1" name="ground" width="2" height="1">
+      <data encoding="csv">1,2</data>
+    </layer>
+  </group>
+</map>`
+
+    const map = parseTmx(xml)
+    expect(map.width).toBe(2)
+    expect(map.tilesets).toHaveLength(1)
+    expect(map.layers).toHaveLength(1)
+    expect(map.layers[0]!.type).toBe('group')
+    const group = map.layers[0] as { layers: { name: string }[] }
+    expect(group.layers[0]!.name).toBe('ground')
+  })
+
+  it('parses a TSX tileset', () => {
+    DOMAdapter.set(WebWorkerAdapter)
+
+    const ts = parseTsx(
+      `<tileset name="terrain" tilewidth="32" tileheight="32" tilecount="4" columns="2">
+         <image source="terrain.png" width="64" height="64"/>
+       </tileset>`
+    )
+    expect(ts.name).toBe('terrain')
+    expect(ts.image).toBe('terrain.png')
+  })
+
+  it('parses a TX object template', () => {
+    DOMAdapter.set(WebWorkerAdapter)
+
+    const tpl = parseTx(
+      `<template>
+         <object name="spawnpoint" type="marker">
+           <point/>
+         </object>
+       </template>`
+    )
+    expect(tpl.type).toBe('template')
+    expect(tpl.object.name).toBe('spawnpoint')
+    expect(tpl.object.point).toBe(true)
   })
 })


### PR DESCRIPTION
Fixes #29.

## Problem
`parseTmx`, `parseTsx`, and `parseTx` used the browser-only `DOMParser` API directly, so they threw in web workers and Node.

## Fix
Route XML parsing through PixiJS'' `DOMAdapter` (`DOMAdapter.get().parseXML`), which uses the browser `DOMParser` in browsers and `@xmldom/xmldom` under `WebWorkerAdapter` — exactly the `Adapter`-interface approach suggested in the issue.

While implementing, I found `@xmldom/xmldom` 0.8.x (pinned by Pixi via `^0.8.12`) also lacks `Document.querySelector` and `Element.children`, which the parser relied on. So the fix additionally:

- Detects malformed-XML `<parsererror>` via `getElementsByTagName` instead of `querySelector`.
- Iterates element children via `childNodes` filtered by `nodeType` (new `elementChildren` helper + `isElementNode` predicate) instead of `Element.children`, in `xmlHelpers` and `parseLayers`.

The three duplicated `DOMParser` blocks are consolidated into a shared `parseXmlDocument` helper.

## Notes for consumers
In the browser the default adapter is used automatically. In a web worker or Node there is no global `DOMParser`, so the consumer must configure an adapter once at startup (documented in the README):

```ts
import { DOMAdapter, WebWorkerAdapter } from ''pixi.js''
DOMAdapter.set(WebWorkerAdapter)
```

## Tests
- New regression suite drives all three parsers (`parseTmx`/`parseTsx`/`parseTx`) through Pixi''s `WebWorkerAdapter` (xmldom), covering the worker/Node code path.
- Full suite green: `npm test` → 187 tests pass (build + typecheck + MagicLand visual regression). `npm run check` (Biome) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)