### PR TITLE
Bump undici to 7.28.0 (clear Dependabot alerts)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -707,9 +707,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -727,9 +724,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -747,9 +741,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -767,9 +758,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -787,9 +775,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -807,9 +792,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2335,9 +2317,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
Bumps the transitive `undici` dependency from 7.25.0 to 7.28.0 to clear 6 Dependabot alerts.

## Impact: dev-tree only
`undici` is pulled in **only by `jsdom`**, which is a **devDependency** (used in tests). The published package ships only `dist/` (`files: ["dist"]`) and has no runtime dependency on undici, so **consumers of `pixi-tiledmap` were never affected**. This is purely dev/test-tree hygiene.

## Change
`jsdom@29.1.1` (already the latest jsdom) allows `undici@^7.25.0`, so 7.28.0 is in-range — this is a **lockfile-only** update. No `package.json` or `jsdom` change required.

## Alerts cleared
| Sev | GHSA |
| --- | --- |
| high | GHSA-hm92-r4w5-c3mj (SOCKS5 proxy pool reuse) |
| high | GHSA-vmh5-mc38-953g (TLS validation bypass via dropped requestTls) |
| medium | GHSA-p88m-4jfj-68fv (Set-Cookie header injection) |
| medium | GHSA-pr7r-676h-xcf6 (shared cache whitespace bypass) |
| low | GHSA-g8m3-5g58-fq7m (SameSite downgrade) |
| low | GHSA-35p6-xmwp-9g52 (response queue poisoning) |

## Verification
- `npm audit` → **0 vulnerabilities**.
- Parser + MagicLand visual regression tests pass on the updated tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)